### PR TITLE
Add persona landing page

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -17,9 +17,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { LiveAPIProvider } from './contexts/LiveAPIContext';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders landing page', () => {
+  render(
+    <LiveAPIProvider options={{ apiKey: 'test-key' }}>
+      <App />
+    </LiveAPIProvider>
+  );
+  const heading = screen.getByText(/select a persona/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -1,0 +1,16 @@
+import "./landing.scss";
+
+export type Persona = "prospect" | "lead" | "candidate";
+
+export default function LandingPage({ onSelect }: { onSelect: (p: Persona) => void }) {
+  return (
+    <div className="landing-page">
+      <h1>Select a Persona</h1>
+      <div className="persona-options">
+        <button className="persona-button" onClick={() => onSelect("prospect")}>Prospect</button>
+        <button className="persona-button" onClick={() => onSelect("lead")}>Lead</button>
+        <button className="persona-button" onClick={() => onSelect("candidate")}>Candidate</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/landing.scss
+++ b/src/components/landing/landing.scss
@@ -1,0 +1,35 @@
+.landing-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: var(--Neutral-30);
+  color: var(--Neutral-90);
+  font-family: var(--font-family);
+  gap: 1rem;
+
+  h1 {
+    margin-bottom: 1rem;
+  }
+
+  .persona-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .persona-button {
+    background: var(--Neutral-10);
+    color: var(--Neutral-90);
+    border: 1px solid var(--Neutral-20);
+    border-radius: 8px;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    font-size: 1rem;
+
+    &:hover {
+      background: var(--Neutral-20);
+    }
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,13 +19,21 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { LiveAPIProvider } from './contexts/LiveAPIContext';
+
+const API_KEY = process.env.REACT_APP_GEMINI_API_KEY as string;
+if (typeof API_KEY !== 'string') {
+  throw new Error('set REACT_APP_GEMINI_API_KEY in .env');
+}
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <LiveAPIProvider options={{ apiKey: API_KEY }}>
+      <App />
+    </LiveAPIProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add LandingPage component with options for Prospect, Lead and Candidate
- switch to use LiveAPIProvider in `index.tsx`
- update `App.tsx` to show landing page and apply persona instructions
- adjust unit test to render through provider

## Testing
- `npm test --silent` *(fails: react-scripts not found)*