### PR TITLE
Add Azure AD authentication via MSAL

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,6 @@
 # create your own API KEY at https://aistudio.google.com/apikey
 #REACT_APP_GEMINI_API_KEY=''
+
+# Azure Active Directory credentials
+#REACT_APP_AZURE_CLIENT_ID=''
+#REACT_APP_AZURE_TENANT_ID=''

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "react-syntax-highlighter": "^15.6.1",
     "sass": "^1.80.6",
     "web-vitals": "^2.1.4",
-    "zustand": "^5.0.1"
+    "zustand": "^5.0.1",
+    "@azure/msal-browser": "^3.0.0",
+    "@azure/msal-react": "^1.5.0"
   },
   "scripts": {
     "start-https": "HTTPS=true react-scripts start",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,20 +20,46 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { LiveAPIProvider } from './contexts/LiveAPIContext';
+import { PublicClientApplication } from '@azure/msal-browser';
+import {
+  MsalProvider,
+  MsalAuthenticationTemplate,
+  InteractionType,
+} from '@azure/msal-react';
 
 const API_KEY = process.env.REACT_APP_GEMINI_API_KEY as string;
 if (typeof API_KEY !== 'string') {
   throw new Error('set REACT_APP_GEMINI_API_KEY in .env');
 }
 
+const AZURE_CLIENT_ID = process.env.REACT_APP_AZURE_CLIENT_ID as string;
+const AZURE_TENANT_ID = process.env.REACT_APP_AZURE_TENANT_ID as string;
+if (!AZURE_CLIENT_ID || !AZURE_TENANT_ID) {
+  throw new Error(
+    'set REACT_APP_AZURE_CLIENT_ID and REACT_APP_AZURE_TENANT_ID in .env'
+  );
+}
+
+const msalInstance = new PublicClientApplication({
+  auth: {
+    clientId: AZURE_CLIENT_ID,
+    authority: `https://login.microsoftonline.com/${AZURE_TENANT_ID}`,
+    redirectUri: window.location.origin,
+  },
+});
+
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <LiveAPIProvider options={{ apiKey: API_KEY }}>
-      <App />
-    </LiveAPIProvider>
+    <MsalProvider instance={msalInstance}>
+      <MsalAuthenticationTemplate interactionType={InteractionType.Redirect}>
+        <LiveAPIProvider options={{ apiKey: API_KEY }}>
+          <App />
+        </LiveAPIProvider>
+      </MsalAuthenticationTemplate>
+    </MsalProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- secure the app with Azure Active Directory
- wrap the app in MSAL providers so users must be authenticated
- document needed env vars for Azure
- add MSAL packages to package.json

## Testing
- `npm test --silent` *(fails: react-scripts not found)*