### PR TITLE
Add audio capture to logs with playback panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useLiveAPIContext } from "./contexts/LiveAPIContext";
 import SidePanel from "./components/side-panel/SidePanel";
 import ControlTray from "./components/control-tray/ControlTray";
 import LandingPage, { Persona } from "./components/landing/LandingPage";
+import AudioLogPanel from "./components/audio-log-panel/AudioLogPanel";
 import cn from "classnames";
 import { useMsal } from "@azure/msal-react";
 
@@ -78,6 +79,7 @@ function App() {
             enableEditingSettings={true}
           ></ControlTray>
         </main>
+        <AudioLogPanel />
       </div>
     </div>
   );

--- a/src/components/audio-log-panel/AudioLogPanel.tsx
+++ b/src/components/audio-log-panel/AudioLogPanel.tsx
@@ -1,0 +1,58 @@
+import "./audio-log-panel.scss";
+import { useEffect, useState } from "react";
+import { useLoggerStore } from "../../lib/store-logger";
+import { pcm16ToWav } from "../../lib/utils";
+
+/**
+ * Simple panel that renders a list of audio events.
+ * User sent audio is shown as a message from the user and
+ * AI sent audio as a message from the AI.
+ */
+export default function AudioLogPanel() {
+  const { logs } = useLoggerStore();
+  const [messages, setMessages] = useState<
+    {
+      id: number;
+      sender: "user" | "ai";
+      url: string;
+    }[]
+  >([]);
+
+  useEffect(() => {
+    const filtered = logs
+      .filter(
+        (l) => l.type === "client.realtimeInput" || l.type === "server.audio",
+      )
+      .map((l, idx) => {
+        const sender = l.type === "server.audio" ? "ai" : "user";
+        let url = "";
+        if (l.audio) {
+          const blob = pcm16ToWav(l.audio);
+          url = URL.createObjectURL(blob);
+        }
+        return { id: idx, sender, url };
+      });
+    // revoke old URLs
+    messages.forEach((m) => URL.revokeObjectURL(m.url));
+    setMessages(filtered);
+  }, [logs]);
+
+  return (
+    <div className="audio-log-panel">
+      <h2>Audio</h2>
+      <ul>
+        {messages.map((m) => (
+          <li key={m.id} className={m.sender}>
+            {m.url ? (
+              <audio controls src={m.url} />
+            ) : m.sender === "user" ? (
+              "User sent audio"
+            ) : (
+              "AI sent audio"
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/audio-log-panel/audio-log-panel.scss
+++ b/src/components/audio-log-panel/audio-log-panel.scss
@@ -1,0 +1,36 @@
+.audio-log-panel {
+  width: 200px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--Neutral-00);
+  color: var(--Neutral-90);
+  border-left: 1px solid var(--gray-600);
+
+  h2 {
+    margin: 12px;
+    font-size: 21px;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0 12px;
+    margin: 0;
+    overflow-y: auto;
+    flex-grow: 1;
+  }
+
+  li {
+    margin-bottom: 8px;
+  }
+
+  li.user {
+    text-align: right;
+    color: var(--Green-500);
+  }
+
+  li.ai {
+    text-align: left;
+    color: var(--Blue-500);
+  }
+}

--- a/src/components/side-panel/SidePanel.tsx
+++ b/src/components/side-panel/SidePanel.tsx
@@ -18,32 +18,20 @@ import "./react-select.scss";
 import cn from "classnames";
 import { useCallback, useEffect, useMemo, useRef, useState, ChangeEvent } from "react";
 import { RiSidebarFoldLine, RiSidebarUnfoldLine } from "react-icons/ri";
-import Select from "react-select";
 import { useLiveAPIContext } from "../../contexts/LiveAPIContext";
 import ResponseModalitySelector from "../settings-dialog/ResponseModalitySelector";
 import VoiceSelector from "../settings-dialog/VoiceSelector";
 import { useLoggerStore } from "../../lib/store-logger";
-import Logger, { LoggerFilterType } from "../logger/Logger";
 import "./side-panel.scss";
 
-const filterOptions = [
-  { value: "conversations", label: "Conversations" },
-  { value: "tools", label: "Tool Use" },
-  { value: "none", label: "All" },
-];
+
 
 export default function SidePanel() {
   const { connected, client, config, setConfig } = useLiveAPIContext();
   const [open, setOpen] = useState(true);
-  const loggerRef = useRef<HTMLDivElement>(null);
-  const loggerLastHeightRef = useRef<number>(-1);
-  const { log, logs } = useLoggerStore();
+  const { log } = useLoggerStore();
 
   const [textInput, setTextInput] = useState("");
-  const [selectedOption, setSelectedOption] = useState<{
-    value: string;
-    label: string;
-  } | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const systemInstruction = useMemo(() => {
@@ -74,17 +62,6 @@ export default function SidePanel() {
     [config, setConfig]
   );
 
-  //scroll the log to the bottom when new logs come in
-  useEffect(() => {
-    if (loggerRef.current) {
-      const el = loggerRef.current;
-      const scrollHeight = el.scrollHeight;
-      if (scrollHeight !== loggerLastHeightRef.current) {
-        el.scrollTop = scrollHeight;
-        loggerLastHeightRef.current = scrollHeight;
-      }
-    }
-  }, [logs]);
 
   // listen for log events and store them
   useEffect(() => {
@@ -130,44 +107,12 @@ export default function SidePanel() {
         />
       </section>
       <section className="indicators">
-        <Select
-          className="react-select"
-          classNamePrefix="react-select"
-          styles={{
-            control: (baseStyles) => ({
-              ...baseStyles,
-              background: "var(--Neutral-15)",
-              color: "var(--Neutral-90)",
-              minHeight: "33px",
-              maxHeight: "33px",
-              border: 0,
-            }),
-            option: (styles, { isFocused, isSelected }) => ({
-              ...styles,
-              backgroundColor: isFocused
-                ? "var(--Neutral-30)"
-                : isSelected
-                  ? "var(--Neutral-20)"
-                  : undefined,
-            }),
-          }}
-          defaultValue={selectedOption}
-          options={filterOptions}
-          onChange={(e) => {
-            setSelectedOption(e);
-          }}
-        />
         <div className={cn("streaming-indicator", { connected })}>
           {connected
             ? `🔵${open ? " Streaming" : ""}`
             : `⏸️${open ? " Paused" : ""}`}
         </div>
       </section>
-      <div className="side-panel-container" ref={loggerRef}>
-        <Logger
-          filter={(selectedOption?.value as LoggerFilterType) || "none"}
-        />
-      </div>
       <div className={cn("input-container", { disabled: !connected })}>
         <div className="input-content">
           <textarea

--- a/src/lib/store-logger.ts
+++ b/src/lib/store-logger.ts
@@ -28,7 +28,7 @@ interface StoreLoggerState {
 export const useLoggerStore = create<StoreLoggerState>((set, get) => ({
   maxLogs: 100,
   logs: [], //mockLogs,
-  log: ({ date, type, message }: StreamingLog) => {
+  log: ({ date, type, message, audio }: StreamingLog) => {
     set((state) => {
       const prevLog = state.logs.at(-1);
       if (prevLog && prevLog.type === type && prevLog.message === message) {
@@ -39,6 +39,7 @@ export const useLoggerStore = create<StoreLoggerState>((set, get) => ({
               date,
               type,
               message,
+              audio,
               count: prevLog.count ? prevLog.count + 1 : 1,
             } as StreamingLog,
           ],
@@ -51,6 +52,7 @@ export const useLoggerStore = create<StoreLoggerState>((set, get) => ({
             date,
             type,
             message,
+            audio,
           } as StreamingLog,
         ],
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export type StreamingLog = {
   date: Date;
   type: string;
   count?: number;
+  /** optional audio data associated with the log */
+  audio?: ArrayBuffer;
   message:
     | string
     | ClientContentLog


### PR DESCRIPTION
## Summary
- extend `StreamingLog` to store optional audio data
- log sent and received audio buffers in `GenAILiveClient`
- expose a new `pcm16ToWav` helper to create playable audio blobs
- render log audio clips in `AudioLogPanel`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*