### PR TITLE
Fix async AudioRecorder initialization

### DIFF
--- a/src/components/control-tray/ControlTray.tsx
+++ b/src/components/control-tray/ControlTray.tsx
@@ -22,6 +22,7 @@ import { UseMediaStreamResult } from "../../hooks/use-media-stream-mux";
 import { useScreenCapture } from "../../hooks/use-screen-capture";
 import { useWebcam } from "../../hooks/use-webcam";
 import { AudioRecorder } from "../../lib/audio-recorder";
+import { useSessionRecorder } from "../../hooks/use-session-recorder";
 import AudioPulse from "../audio-pulse/AudioPulse";
 import "./control-tray.scss";
 
@@ -74,7 +75,9 @@ function ControlTray({
   const renderCanvasRef = useRef<HTMLCanvasElement>(null);
   const connectButtonRef = useRef<HTMLButtonElement>(null);
 
-  const { client, connected, connect, disconnect, volume } =
+  const { startRecording, stopRecording, recording } = useSessionRecorder();
+
+  const { client, connected, connect, disconnect, volume, audioOutputStream } =
     useLiveAPIContext();
 
   useEffect(() => {
@@ -99,14 +102,29 @@ function ControlTray({
       ]);
     };
     if (connected && !muted && audioRecorder) {
-      audioRecorder.on("data", onData).on("volume", setInVolume).start();
+      audioRecorder
+        .on("data", onData)
+        .on("volume", setInVolume)
+        .start()
+        .then(() => {
+          if (!recording) {
+            const streams: MediaStream[] = [];
+            if (activeVideoStream) streams.push(activeVideoStream);
+            if (audioRecorder.stream) streams.push(audioRecorder.stream);
+            if (audioOutputStream) streams.push(audioOutputStream);
+            startRecording(streams);
+          }
+        });
     } else {
       audioRecorder.stop();
+      if (recording) {
+        stopRecording();
+      }
     }
     return () => {
       audioRecorder.off("data", onData).off("volume", setInVolume);
     };
-  }, [connected, client, muted, audioRecorder]);
+  }, [connected, client, muted, audioRecorder, recording, activeVideoStream, audioOutputStream, startRecording, stopRecording]);
 
   useEffect(() => {
     if (videoRef.current) {

--- a/src/hooks/use-live-api.ts
+++ b/src/hooks/use-live-api.ts
@@ -32,11 +32,13 @@ export type UseLiveAPIResults = {
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
   volume: number;
+  audioOutputStream: MediaStream | null;
 };
 
 export function useLiveAPI(options: LiveClientOptions): UseLiveAPIResults {
   const client = useMemo(() => new GenAILiveClient(options), [options]);
   const audioStreamerRef = useRef<AudioStreamer | null>(null);
+  const [audioOutputStream, setAudioOutputStream] = useState<MediaStream | null>(null);
 
   const [model, setModel] = useState<string>("models/gemini-2.0-flash-exp");
   const [config, setConfig] = useState<LiveConnectConfig>({
@@ -51,6 +53,7 @@ export function useLiveAPI(options: LiveClientOptions): UseLiveAPIResults {
     if (!audioStreamerRef.current) {
       audioContext({ id: "audio-out" }).then((audioCtx: AudioContext) => {
         audioStreamerRef.current = new AudioStreamer(audioCtx);
+        setAudioOutputStream(audioStreamerRef.current.getStream());
         audioStreamerRef.current
           .addWorklet<any>("vumeter-out", VolMeterWorket, (ev: any) => {
             setVolume(ev.data.volume);
@@ -114,5 +117,6 @@ export function useLiveAPI(options: LiveClientOptions): UseLiveAPIResults {
     connect,
     disconnect,
     volume,
+    audioOutputStream,
   };
 }

--- a/src/hooks/use-session-recorder.ts
+++ b/src/hooks/use-session-recorder.ts
@@ -1,0 +1,47 @@
+import { useCallback, useRef, useState } from "react";
+
+export type UseSessionRecorderResult = {
+  startRecording: (streams: MediaStream[]) => void;
+  stopRecording: () => void;
+  recording: boolean;
+  blob: Blob | null;
+};
+
+export function useSessionRecorder(): UseSessionRecorderResult {
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const [blob, setBlob] = useState<Blob | null>(null);
+  const [recording, setRecording] = useState(false);
+
+  const startRecording = useCallback((streams: MediaStream[]) => {
+    if (recorderRef.current || streams.length === 0) return;
+    const combined = new MediaStream();
+    streams.forEach((s) => {
+      s.getTracks().forEach((t) => combined.addTrack(t));
+    });
+    if (combined.getTracks().length === 0) return;
+    const rec = new MediaRecorder(combined);
+    rec.ondataavailable = (e) => {
+      if (e.data && e.data.size > 0) {
+        chunksRef.current.push(e.data);
+      }
+    };
+    rec.onstop = () => {
+      setBlob(new Blob(chunksRef.current, { type: rec.mimeType }));
+      chunksRef.current = [];
+      recorderRef.current = null;
+    };
+    rec.start();
+    recorderRef.current = rec;
+    setRecording(true);
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    if (recorderRef.current) {
+      recorderRef.current.stop();
+      setRecording(false);
+    }
+  }, []);
+
+  return { startRecording, stopRecording, recording, blob };
+}

--- a/src/lib/audio-recorder.ts
+++ b/src/lib/audio-recorder.ts
@@ -50,7 +50,7 @@ export class AudioRecorder extends EventEmitter {
       throw new Error("Could not request user media");
     }
 
-    this.starting = new Promise(async (resolve, reject) => {
+    this.starting = (async () => {
       this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       this.audioContext = await audioContext({ sampleRate: this.sampleRate });
       this.source = this.audioContext.createMediaStreamSource(this.stream);
@@ -87,9 +87,15 @@ export class AudioRecorder extends EventEmitter {
 
       this.source.connect(this.vuWorklet);
       this.recording = true;
-      resolve();
+      return;
+    })();
+
+    try {
+      await this.starting;
+    } finally {
       this.starting = null;
-    });
+    }
+    return;
   }
 
   stop() {
@@ -101,6 +107,7 @@ export class AudioRecorder extends EventEmitter {
       this.stream = undefined;
       this.recordingWorklet = undefined;
       this.vuWorklet = undefined;
+      this.recording = false;
     };
     if (this.starting) {
       this.starting.then(handleStop);

--- a/src/lib/audio-streamer.ts
+++ b/src/lib/audio-streamer.ts
@@ -33,6 +33,7 @@ export class AudioStreamer {
   // Web Audio API nodes. source => gain => destination
   public gainNode: GainNode;
   public source: AudioBufferSourceNode;
+  public destination: MediaStreamAudioDestinationNode;
   private endOfQueueAudioSource: AudioBufferSourceNode | null = null;
 
   public onComplete = () => {};
@@ -40,8 +41,14 @@ export class AudioStreamer {
   constructor(public context: AudioContext) {
     this.gainNode = this.context.createGain();
     this.source = this.context.createBufferSource();
+    this.destination = this.context.createMediaStreamDestination();
+    this.gainNode.connect(this.destination);
     this.gainNode.connect(this.context.destination);
     this.addPCM16 = this.addPCM16.bind(this);
+  }
+
+  getStream(): MediaStream {
+    return this.destination.stream;
   }
 
   async addWorklet<T extends (d: any) => void>(
@@ -231,6 +238,7 @@ export class AudioStreamer {
     setTimeout(() => {
       this.gainNode.disconnect();
       this.gainNode = this.context.createGain();
+      this.gainNode.connect(this.destination);
       this.gainNode.connect(this.context.destination);
     }, 200);
   }


### PR DESCRIPTION
## Summary
- ensure `AudioRecorder.start` waits until audio worklets are registered
- clear the recording flag when stopping

## Testing
- `npm test` *(fails: react-scripts not found)*