### PR TITLE
Fix audio worklet error and record both sides

### DIFF
--- a/src/hooks/use-session-recorder.ts
+++ b/src/hooks/use-session-recorder.ts
@@ -15,11 +15,30 @@ export function useSessionRecorder(): UseSessionRecorderResult {
 
   const startRecording = useCallback((streams: MediaStream[]) => {
     if (recorderRef.current || streams.length === 0) return;
+
     const combined = new MediaStream();
+    const audioTracks: MediaStreamTrack[] = [];
+
     streams.forEach((s) => {
-      s.getTracks().forEach((t) => combined.addTrack(t));
+      s.getVideoTracks().forEach((t) => combined.addTrack(t));
+      audioTracks.push(...s.getAudioTracks());
     });
+
+    if (audioTracks.length === 1) {
+      combined.addTrack(audioTracks[0]);
+    } else if (audioTracks.length > 1) {
+      const ctx = new AudioContext();
+      const destination = ctx.createMediaStreamDestination();
+      audioTracks.forEach((t) => {
+        const src = ctx.createMediaStreamSource(new MediaStream([t]));
+        src.connect(destination);
+      });
+      const mixed = destination.stream.getAudioTracks()[0];
+      if (mixed) combined.addTrack(mixed);
+    }
+
     if (combined.getTracks().length === 0) return;
+
     const rec = new MediaRecorder(combined);
     rec.ondataavailable = (e) => {
       if (e.data && e.data.size > 0) {

--- a/src/lib/audio-recorder.ts
+++ b/src/lib/audio-recorder.ts
@@ -46,11 +46,15 @@ export class AudioRecorder extends EventEmitter {
   }
 
   async start() {
+    if (this.recording || this.starting) {
+      return this.starting ?? Promise.resolve();
+    }
+
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
       throw new Error("Could not request user media");
     }
 
-    this.starting = new Promise(async (resolve, reject) => {
+    this.starting = new Promise(async (resolve) => {
       this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       this.audioContext = await audioContext({ sampleRate: this.sampleRate });
       this.source = this.audioContext.createMediaStreamSource(this.stream);
@@ -101,6 +105,7 @@ export class AudioRecorder extends EventEmitter {
       this.stream = undefined;
       this.recordingWorklet = undefined;
       this.vuWorklet = undefined;
+      this.recording = false;
     };
     if (this.starting) {
       this.starting.then(handleStop);


### PR DESCRIPTION
## Summary
- prevent duplicate audio worklet initialization and reset recording state
- mix microphone and AI output streams when recording sessions so both sides are captured

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*