### PR TITLE
Fix audio mixing for session recordings

### DIFF
--- a/src/hooks/use-session-recorder.ts
+++ b/src/hooks/use-session-recorder.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { audioContext } from "../lib/utils";
 
 export type UseSessionRecorderResult = {
   startRecording: (streams: MediaStream[]) => void;
@@ -13,33 +14,66 @@ export function useSessionRecorder(): UseSessionRecorderResult {
   const [blob, setBlob] = useState<Blob | null>(null);
   const [recording, setRecording] = useState(false);
 
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
   const startRecording = useCallback((streams: MediaStream[]) => {
     if (recorderRef.current || streams.length === 0) return;
-    const combined = new MediaStream();
-    streams.forEach((s) => {
-      s.getTracks().forEach((t) => combined.addTrack(t));
-    });
-    if (combined.getTracks().length === 0) return;
-    const rec = new MediaRecorder(combined);
-    rec.ondataavailable = (e) => {
-      if (e.data && e.data.size > 0) {
-        chunksRef.current.push(e.data);
+
+    (async () => {
+      const combined = new MediaStream();
+      const audioTracks: MediaStreamTrack[] = [];
+
+      streams.forEach((s) => {
+        s.getVideoTracks().forEach((t) => combined.addTrack(t));
+        audioTracks.push(...s.getAudioTracks());
+      });
+
+      if (audioTracks.length === 1) {
+        combined.addTrack(audioTracks[0]);
+      } else if (audioTracks.length > 1) {
+        const ctx = await audioContext({ id: "session-recorder" });
+        audioCtxRef.current = ctx;
+        if (ctx.state === "suspended") {
+          await ctx.resume();
+        }
+        const destination = ctx.createMediaStreamDestination();
+        audioTracks.forEach((t) => {
+          const src = ctx.createMediaStreamSource(new MediaStream([t]));
+          src.connect(destination);
+        });
+        const mixed = destination.stream.getAudioTracks()[0];
+        if (mixed) combined.addTrack(mixed);
       }
-    };
-    rec.onstop = () => {
-      setBlob(new Blob(chunksRef.current, { type: rec.mimeType }));
-      chunksRef.current = [];
-      recorderRef.current = null;
-    };
-    rec.start();
-    recorderRef.current = rec;
-    setRecording(true);
+
+      if (combined.getTracks().length === 0) return;
+
+      const rec = new MediaRecorder(combined);
+      rec.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) {
+          chunksRef.current.push(e.data);
+        }
+      };
+      rec.onstop = () => {
+        setBlob(new Blob(chunksRef.current, { type: rec.mimeType }));
+        chunksRef.current = [];
+        recorderRef.current = null;
+        audioCtxRef.current?.close();
+        audioCtxRef.current = null;
+      };
+      rec.start();
+      recorderRef.current = rec;
+      setRecording(true);
+    })();
   }, []);
 
   const stopRecording = useCallback(() => {
     if (recorderRef.current) {
       recorderRef.current.stop();
       setRecording(false);
+    }
+    if (audioCtxRef.current) {
+      audioCtxRef.current.close();
+      audioCtxRef.current = null;
     }
   }, []);
 

--- a/src/lib/audio-recorder.ts
+++ b/src/lib/audio-recorder.ts
@@ -46,19 +46,32 @@ export class AudioRecorder extends EventEmitter {
   }
 
   async start() {
+    if (this.recording || this.starting) {
+      return this.starting ?? Promise.resolve();
+    }
+
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
       throw new Error("Could not request user media");
     }
 
-    this.starting = new Promise(async (resolve, reject) => {
+    this.starting = new Promise(async (resolve) => {
       this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       this.audioContext = await audioContext({ sampleRate: this.sampleRate });
       this.source = this.audioContext.createMediaStreamSource(this.stream);
 
       const workletName = "audio-recorder-worklet";
-      const src = createWorketFromSrc(workletName, AudioRecordingWorklet);
+      let workletsRecord = registeredWorklets.get(this.audioContext);
+      if (!workletsRecord) {
+        registeredWorklets.set(this.audioContext, {});
+        workletsRecord = registeredWorklets.get(this.audioContext)!;
+      }
 
-      await this.audioContext.audioWorklet.addModule(src);
+      if (!workletsRecord[workletName]) {
+        const src = createWorketFromSrc(workletName, AudioRecordingWorklet);
+        await this.audioContext.audioWorklet.addModule(src);
+        workletsRecord[workletName] = { handlers: [] };
+      }
+
       this.recordingWorklet = new AudioWorkletNode(
         this.audioContext,
         workletName,
@@ -77,9 +90,12 @@ export class AudioRecorder extends EventEmitter {
 
       // vu meter worklet
       const vuWorkletName = "vu-meter";
-      await this.audioContext.audioWorklet.addModule(
-        createWorketFromSrc(vuWorkletName, VolMeterWorket),
-      );
+      if (!workletsRecord[vuWorkletName]) {
+        await this.audioContext.audioWorklet.addModule(
+          createWorketFromSrc(vuWorkletName, VolMeterWorket),
+        );
+        workletsRecord[vuWorkletName] = { handlers: [] };
+      }
       this.vuWorklet = new AudioWorkletNode(this.audioContext, vuWorkletName);
       this.vuWorklet.port.onmessage = (ev: MessageEvent) => {
         this.emit("volume", ev.data.volume);
@@ -101,6 +117,7 @@ export class AudioRecorder extends EventEmitter {
       this.stream = undefined;
       this.recordingWorklet = undefined;
       this.vuWorklet = undefined;
+      this.recording = false;
     };
     if (this.starting) {
       this.starting.then(handleStop);


### PR DESCRIPTION
## Summary
- ensure session recorder mixes mic and output tracks using a resumed AudioContext
- close the mixing AudioContext after stopping recordings
- avoid duplicate audio worklet initialization in `AudioRecorder`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*