### PR TITLE
Fix audio worklet error and record both sides

### DIFF
--- a/src/hooks/use-session-recorder.ts
+++ b/src/hooks/use-session-recorder.ts
@@ -1,7 +1,8 @@
 import { useCallback, useRef, useState } from "react";
+import { audioContext } from "../lib/utils";
 
 export type UseSessionRecorderResult = {
-  startRecording: (streams: MediaStream[]) => void;
+  startRecording: (streams: MediaStream[]) => Promise<void>;
   stopRecording: () => void;
   recording: boolean;
   blob: Blob | null;
@@ -13,13 +14,37 @@ export function useSessionRecorder(): UseSessionRecorderResult {
   const [blob, setBlob] = useState<Blob | null>(null);
   const [recording, setRecording] = useState(false);
 
-  const startRecording = useCallback((streams: MediaStream[]) => {
+  const contextRef = useRef<AudioContext | null>(null);
+
+  const startRecording = useCallback(async (streams: MediaStream[]) => {
     if (recorderRef.current || streams.length === 0) return;
+
     const combined = new MediaStream();
+    const audioTracks: MediaStreamTrack[] = [];
+
     streams.forEach((s) => {
-      s.getTracks().forEach((t) => combined.addTrack(t));
+      s.getVideoTracks().forEach((t) => combined.addTrack(t));
+      audioTracks.push(...s.getAudioTracks().map((t) => t.clone()));
     });
+
+    if (audioTracks.length === 1) {
+      combined.addTrack(audioTracks[0]);
+    } else if (audioTracks.length > 1) {
+      const ctx = await audioContext({ id: "session-recorder" });
+      contextRef.current = ctx;
+      if (ctx.state === "suspended") await ctx.resume();
+
+      const destination = ctx.createMediaStreamDestination();
+      audioTracks.forEach((t) => {
+        const src = ctx.createMediaStreamSource(new MediaStream([t]));
+        src.connect(destination);
+      });
+      const mixed = destination.stream.getAudioTracks()[0];
+      if (mixed) combined.addTrack(mixed);
+    }
+
     if (combined.getTracks().length === 0) return;
+
     const rec = new MediaRecorder(combined);
     rec.ondataavailable = (e) => {
       if (e.data && e.data.size > 0) {
@@ -40,6 +65,10 @@ export function useSessionRecorder(): UseSessionRecorderResult {
     if (recorderRef.current) {
       recorderRef.current.stop();
       setRecording(false);
+    }
+    if (contextRef.current) {
+      contextRef.current.close();
+      contextRef.current = null;
     }
   }, []);
 

--- a/src/lib/audio-recorder.ts
+++ b/src/lib/audio-recorder.ts
@@ -17,8 +17,7 @@
 import { audioContext } from "./utils";
 import AudioRecordingWorklet from "./worklets/audio-processing";
 import VolMeterWorket from "./worklets/vol-meter";
-
-import { createWorketFromSrc } from "./audioworklet-registry";
+import { createWorketFromSrc, registeredWorklets } from "./audioworklet-registry";
 import EventEmitter from "eventemitter3";
 
 function arrayBufferToBase64(buffer: ArrayBuffer) {
@@ -46,11 +45,15 @@ export class AudioRecorder extends EventEmitter {
   }
 
   async start() {
+    if (this.recording || this.starting) {
+      return this.starting ?? Promise.resolve();
+    }
+
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
       throw new Error("Could not request user media");
     }
 
-    this.starting = new Promise(async (resolve, reject) => {
+    this.starting = new Promise(async (resolve) => {
       this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       this.audioContext = await audioContext({ sampleRate: this.sampleRate });
       this.source = this.audioContext.createMediaStreamSource(this.stream);
@@ -58,7 +61,17 @@ export class AudioRecorder extends EventEmitter {
       const workletName = "audio-recorder-worklet";
       const src = createWorketFromSrc(workletName, AudioRecordingWorklet);
 
-      await this.audioContext.audioWorklet.addModule(src);
+      let workletsRecord = registeredWorklets.get(this.audioContext);
+      if (!workletsRecord) {
+        registeredWorklets.set(this.audioContext, {});
+        workletsRecord = registeredWorklets.get(this.audioContext)!;
+      }
+
+      if (!workletsRecord[workletName]) {
+        await this.audioContext.audioWorklet.addModule(src);
+        workletsRecord[workletName] = { handlers: [] };
+      }
+
       this.recordingWorklet = new AudioWorkletNode(
         this.audioContext,
         workletName,
@@ -77,9 +90,12 @@ export class AudioRecorder extends EventEmitter {
 
       // vu meter worklet
       const vuWorkletName = "vu-meter";
-      await this.audioContext.audioWorklet.addModule(
-        createWorketFromSrc(vuWorkletName, VolMeterWorket),
-      );
+      const vuSrc = createWorketFromSrc(vuWorkletName, VolMeterWorket);
+
+      if (!workletsRecord[vuWorkletName]) {
+        await this.audioContext.audioWorklet.addModule(vuSrc);
+        workletsRecord[vuWorkletName] = { handlers: [] };
+      }
       this.vuWorklet = new AudioWorkletNode(this.audioContext, vuWorkletName);
       this.vuWorklet.port.onmessage = (ev: MessageEvent) => {
         this.emit("volume", ev.data.volume);
@@ -99,8 +115,13 @@ export class AudioRecorder extends EventEmitter {
       this.source?.disconnect();
       this.stream?.getTracks().forEach((track) => track.stop());
       this.stream = undefined;
+      this.source = undefined;
       this.recordingWorklet = undefined;
       this.vuWorklet = undefined;
+      this.recording = false;
+      this.audioContext?.close();
+      this.audioContext = undefined;
+      this.starting = null;
     };
     if (this.starting) {
       this.starting.then(handleStop);


### PR DESCRIPTION
## Summary
- avoid duplicate audio worklet initialization and reset recording state
- mix microphone and AI output streams when recording sessions so both sides are captured

## Testing
- `npm test --silent` *(fails: react-scripts not found)*